### PR TITLE
Catch&Freeze EventDay refactoring and optimization

### DIFF
--- a/addons/sourcemod/scripting/MyJailbreak/catch.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/catch.sp
@@ -8,7 +8,7 @@
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, version 3.0, as published by the
  * Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
@@ -128,10 +128,10 @@ char g_sOverlayStartPath[256];
 
 //Info
 public Plugin myinfo = {
-	name = "MyJailbreak - Catch & Freeze", 
-	author = "shanapu", 
-	description = "Event Day for Jailbreak Server", 
-	version = MYJB_VERSION, 
+	name = "MyJailbreak - Catch & Freeze",
+	author = "shanapu",
+	description = "Event Day for Jailbreak Server",
+	version = MYJB_VERSION,
 	url = MYJB_URL_LINK
 };
 
@@ -142,18 +142,18 @@ public void OnPluginStart()
 	// Translation
 	LoadTranslations("MyJailbreak.Warden.phrases");
 	LoadTranslations("MyJailbreak.Catch.phrases");
-	
-	
+
+
 	//Client Commands
 	RegConsoleCmd("sm_setcatch", Command_SetCatch, "Allows the Admin or Warden to set catch as next round");
 	RegConsoleCmd("sm_catch", Command_VoteCatch, "Allows players to vote for a catch ");
 	RegConsoleCmd("sm_sprint", Command_StartSprint, "Start sprinting!");
-	
-	
+
+
 	//AutoExecConfig
 	AutoExecConfig_SetFile("Catch", "MyJailbreak/EventDays");
 	AutoExecConfig_SetCreateFile(true);
-	
+
 	AutoExecConfig_CreateConVar("sm_catch_version", MYJB_VERSION, "The version of this MyJailbreak SourceMod plugin", FCVAR_SPONLY|FCVAR_REPLICATED|FCVAR_NOTIFY|FCVAR_DONTRECORD);
 	gc_bPlugin = AutoExecConfig_CreateConVar("sm_catch_enable", "1", "0 - disabled, 1 - enable this MyJailbreak SourceMod plugin", _, true, 0.0, true, 1.0);
 	gc_sCustomCommandVote = AutoExecConfig_CreateConVar("sm_catch_cmds_vote", "cat, catchfreeze", "Set your custom chat command for Event voting(!catch (no 'sm_'/'!')(seperate with comma ', ')(max. 12 commands))");
@@ -185,11 +185,11 @@ public void OnPluginStart()
 	gc_fSprintSpeed = AutoExecConfig_CreateConVar("sm_catch_sprint_speed", "1.25", "Ratio for how fast the player will sprint", _, true, 1.01);
 	gc_fSprintTime = AutoExecConfig_CreateConVar("sm_catch_sprint_time", "3.0", "Time in seconds the player will sprint", _, true, 1.0);
 	gc_bAllowLR = AutoExecConfig_CreateConVar("sm_catch_allow_lr", "0" , "0 - disabled, 1 - enable LR for last round and end eventday", _, true, 0.0, true, 1.0);
-	
+
 	AutoExecConfig_ExecuteFile();
 	AutoExecConfig_CleanFile();
-	
-	
+
+
 	//Hooks
 	HookEvent("round_start", Event_RoundStart);
 	HookEvent("player_spawn", Event_PlayerSpawn);
@@ -202,8 +202,8 @@ public void OnPluginStart()
 	HookConVarChange(gc_sSoundFreezePath, OnSettingChanged);
 	HookConVarChange(gc_sSoundUnFreezePath, OnSettingChanged);
 	HookConVarChange(gc_sAdminFlag, OnSettingChanged);
-	
-	
+
+
 	//FindConVar
 	g_iMaxRound = gc_iRounds.IntValue;
 	g_iCoolDown = gc_iCooldownDay.IntValue + 1;
@@ -215,7 +215,7 @@ public void OnPluginStart()
 	gc_sSoundUnFreezePath.GetString(g_sSoundUnFreezePath, sizeof(g_sSoundUnFreezePath));
 	gc_sOverlayFreeze.GetString(g_sOverlayFreeze , sizeof(g_sOverlayFreeze));
 	gc_sAdminFlag.GetString(g_sAdminFlag , sizeof(g_sAdminFlag));
-	
+
 	SetLogFile(g_sEventsLogFile, "Events", "MyJailbreak");
 }
 
@@ -261,31 +261,31 @@ public void OnConfigsExecuted()
 	g_iFreezeTime = gc_iFreezeTime.IntValue;
 	g_iCoolDown = gc_iCooldownStart.IntValue + 1;
 	g_iMaxRound = gc_iRounds.IntValue;
-	
+
 	//FindConVar
 	g_iTerrorForLR = FindConVar("sm_hosties_lr_ts_max");
-	
+
 	//Set custom Commands
 	int iCount = 0;
 	char sCommands[128], sCommandsL[12][32], sCommand[32];
-	
+
 	//Vote
 	gc_sCustomCommandVote.GetString(sCommands, sizeof(sCommands));
 	ReplaceString(sCommands, sizeof(sCommands), " ", "");
 	iCount = ExplodeString(sCommands, ",", sCommandsL, sizeof(sCommandsL), sizeof(sCommandsL[]));
-	
+
 	for (int i = 0; i < iCount; i++)
 	{
 		Format(sCommand, sizeof(sCommand), "sm_%s", sCommandsL[i]);
 		if (GetCommandFlags(sCommand) == INVALID_FCVAR_FLAGS)  //if command not already exist
 			RegConsoleCmd(sCommand, Command_VoteCatch, "Allows players to vote for a catch ");
 	}
-	
+
 	//Set
 	gc_sCustomCommandSet.GetString(sCommands, sizeof(sCommands));
 	ReplaceString(sCommands, sizeof(sCommands), " ", "");
 	iCount = ExplodeString(sCommands, ",", sCommandsL, sizeof(sCommandsL), sizeof(sCommandsL[]));
-	
+
 	for (int i = 0; i < iCount; i++)
 	{
 		Format(sCommand, sizeof(sCommand), "sm_%s", sCommandsL[i]);
@@ -318,7 +318,7 @@ public Action Command_SetCatch(int client, int args)
 				{
 					char EventDay[64];
 					MyJailbreak_GetEventDayName(EventDay);
-					
+
 					if (StrEqual(EventDay, "none", false))
 					{
 						if (g_iCoolDown == 0)
@@ -342,7 +342,7 @@ public Action Command_SetCatch(int client, int args)
 					{
 						char EventDay[64];
 						MyJailbreak_GetEventDayName(EventDay);
-						
+
 						if (StrEqual(EventDay, "none", false))
 						{
 							if ((g_iCoolDown == 0) || gc_bSetABypassCooldown.BoolValue)
@@ -370,7 +370,7 @@ public Action Command_VoteCatch(int client, int args)
 {
 	char steamid[64];
 	GetClientAuthId(client, AuthId_Steam2, steamid, sizeof(steamid));
-	
+
 	if (gc_bPlugin.BoolValue)
 	{
 		if (gc_bVote.BoolValue)
@@ -379,7 +379,7 @@ public Action Command_VoteCatch(int client, int args)
 			{
 				char EventDay[64];
 				MyJailbreak_GetEventDayName(EventDay);
-				
+
 				if (StrEqual(EventDay, "none", false))
 				{
 					if (g_iCoolDown == 0)
@@ -390,7 +390,7 @@ public Action Command_VoteCatch(int client, int args)
 							g_iVoteCount++;
 							int Missing = playercount - g_iVoteCount + 1;
 							Format(g_sHasVoted, sizeof(g_sHasVoted), "%s, %s", g_sHasVoted, steamid);
-							
+
 							if (g_iVoteCount > playercount)
 							{
 								StartNextRound();
@@ -432,9 +432,9 @@ public void Event_RoundStart(Event event, char[] name, bool dontBroadcast)
 		g_iRound++;
 		StartCatch = false;
 		SJD_OpenDoors();
-		
+
 		if (gc_fBeaconTime.FloatValue > 0.0) BeaconTimer = CreateTimer(gc_fBeaconTime.FloatValue, Timer_BeaconOn, TIMER_FLAG_NO_MAPCHANGE);
-		
+
 		if (g_iRound > 0)
 			{
 				LoopClients(client)
@@ -446,20 +446,20 @@ public void Event_RoundStart(Event event, char[] name, bool dontBroadcast)
 					SetEntData(client, FindSendPropInfo("CBaseEntity", "m_CollisionGroup"), 2, 4, true);
 					SendPanelToClient(CatchMenu, client, Handler_NullCancel, 20);
 					PrintCenterText(client, "%t", "catch_start_nc");
-					
+
 					g_iCatchCounter[client] = 0;
 					catched[client] = false;
-					
+
 					if (GetClientTeam(client) == CS_TEAM_CT)
 					{
 						SetEntityMoveType(client, MOVETYPE_NONE);
 						SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", 0.0);
 					}
 				}
-				
+
 				//enable lr on last round
 				g_iTsLR = GetAliveTeamCount(CS_TEAM_T);
-				
+
 				if (gc_bAllowLR.BoolValue)
 				{
 					if ((g_iRound == g_iMaxRound) && (g_iTsLR > g_iTerrorForLR.IntValue))
@@ -467,7 +467,7 @@ public void Event_RoundStart(Event event, char[] name, bool dontBroadcast)
 						SetCvar("sm_hosties_lr", 1);
 					}
 				}
-				
+
 				g_iFreezeTime--;
 				FreezeTimer = CreateTimer(1.0, Timer_StartEvent, _, TIMER_REPEAT);
 				CPrintToChatAll("%t %t", "catch_tag" , "catch_rounds", g_iRound, g_iMaxRound);
@@ -477,7 +477,7 @@ public void Event_RoundStart(Event event, char[] name, bool dontBroadcast)
 	{
 		char EventDay[64];
 		MyJailbreak_GetEventDayName(EventDay);
-		
+
 		if (!StrEqual(EventDay, "none", false))
 		{
 			g_iCoolDown = gc_iCooldownDay.IntValue + 1;
@@ -491,7 +491,7 @@ public void Event_RoundStart(Event event, char[] name, bool dontBroadcast)
 public void Event_RoundEnd(Event event, char[] name, bool dontBroadcast)
 {
 	int winner = event.GetInt("winner");
-	
+
 	if (IsCatch)
 	{
 		LoopValidClients(client, true, true)
@@ -507,10 +507,10 @@ public void Event_RoundEnd(Event event, char[] name, bool dontBroadcast)
 			}
 			if (gc_bWallhack.BoolValue) UnhookWallhack(client);
 		}
-		
+
 		delete FreezeTimer;
 		delete BeaconTimer;
-		
+
 		if (winner == 2) PrintCenterTextAll("%t", "catch_twin_nc");
 		if (winner == 3) PrintCenterTextAll("%t", "catch_ctwin_nc");
 		if (g_iRound == g_iMaxRound)
@@ -521,7 +521,7 @@ public void Event_RoundEnd(Event event, char[] name, bool dontBroadcast)
 			SetCvar("sm_hosties_lr", 1);
 			SetCvar("sm_weapons_enable", 1);
 			SetCvar("sm_warden_enable", 1);
-			
+
 			g_iMPRoundTime.IntValue = g_iOldRoundTime;
 			MyJailbreak_SetEventDayName("none");
 			MyJailbreak_SetEventDayRunning(false);
@@ -531,7 +531,7 @@ public void Event_RoundEnd(Event event, char[] name, bool dontBroadcast)
 	if (StartCatch)
 	{
 		LoopClients(i) CreateInfoPanel(i);
-		
+
 		CPrintToChatAll("%t %t", "catch_tag" , "catch_next");
 		PrintCenterTextAll("%t", "catch_next_nc");
 	}
@@ -545,7 +545,7 @@ public void Event_PlayerTeam(Event event, const char[] name, bool dontBroadcast)
 		return;
 	}
 	CheckStatus();
-	
+
 	int iClient = GetClientOfUserId(event.GetInt("userid"));
 	ResetSprint(iClient);
 }
@@ -563,9 +563,9 @@ public void OnMapStart()
 	g_iRound = 0;
 	IsCatch = false;
 	StartCatch = false;
-	
+
 	g_iCoolDown = gc_iCooldownStart.IntValue + 1;
-	
+
 	if (gc_bSounds.BoolValue) PrecacheSoundAnyDownload(g_sSoundFreezePath);
 	if (gc_bSounds.BoolValue) PrecacheSoundAnyDownload(g_sSoundUnFreezePath);
 	if (gc_bOverlays.BoolValue) PrecacheDecalAnyDownload(g_sOverlayFreeze);
@@ -604,12 +604,12 @@ public Action CS_OnTerminateRound( float &delay,  CSRoundEndReason &reason)
 public Action OnTakedamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype)
 {
 	if (!IsValidClient(victim, true, false)|| attacker == victim || !IsValidClient(attacker, true, false)) return Plugin_Continue;
-	
+
 	if (IsCatch == false)
 	{
 		return Plugin_Continue;
 	}
-	
+
 	if (GetClientTeam(victim) == CS_TEAM_T && GetClientTeam(attacker) == CS_TEAM_CT && !catched[victim])
 	{
 		if ((g_iCatchCounter[victim] >= gc_iCatchCount.IntValue) && (gc_iCatchCount.IntValue != 0)) ForcePlayerSuicide(victim);
@@ -649,7 +649,7 @@ public Action OnWeaponCanUse(int client, int weapon)
 {
 	char sWeapon[32];
 	GetEdictClassname(weapon, sWeapon, sizeof(sWeapon));
-	
+
 	if (!StrEqual(sWeapon, "weapon_knife"))
 		{
 			if (IsValidClient(client, true, false))
@@ -677,20 +677,20 @@ public void OnAvailableLR(int Announced)
 			SetEntityRenderColor(client, 255, 255, 255, 0);
 			catched[client] = false;
 			SetEntityHealth(client, 100);
-			
+
 			StripAllPlayerWeapons(client);
 			if (GetClientTeam(client) == CS_TEAM_CT)
 			{
 				FakeClientCommand(client, "sm_weapons");
 			}
 			GivePlayerItem(client, "weapon_knife");
-			
+
 			if (gc_bWallhack.BoolValue) UnhookWallhack(client);
 		}
-		
+
 		delete FreezeTimer;
 		delete BeaconTimer;
-		
+
 		if (g_iRound == g_iMaxRound)
 		{
 			IsCatch = false;
@@ -699,7 +699,7 @@ public void OnAvailableLR(int Announced)
 			SetCvar("sm_hosties_lr", 1);
 			SetCvar("sm_weapons_enable", 1);
 			SetCvar("sm_warden_enable", 1);
-			
+
 			g_iMPRoundTime.IntValue = g_iOldRoundTime;
 			MyJailbreak_SetEventDayName("none");
 			MyJailbreak_SetEventDayRunning(false);
@@ -723,10 +723,10 @@ void StartNextRound()
 	Format(buffer, sizeof(buffer), "%T", "catch_name", LANG_SERVER);
 	MyJailbreak_SetEventDayName(buffer);
 	MyJailbreak_SetEventDayPlanned(true);
-	
+
 	g_iOldRoundTime = g_iMPRoundTime.IntValue; //save original round time
 	g_iMPRoundTime.IntValue = gc_iRoundTime.IntValue;//set event round time
-	
+
 	CPrintToChatAll("%t %t", "catch_tag" , "catch_next");
 	PrintCenterTextAll("%t", "catch_next_nc");
 }
@@ -738,13 +738,13 @@ void CatchEm(int client, int attacker)
 	SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", 0.0);
 	SetEntityRenderColor(client, 0, 0, 205, 255);
 	catched[client] = true;
-	g_iCatchCounter[client]++; 
+	g_iCatchCounter[client]++;
 	ShowOverlay(client, g_sOverlayFreeze, 0.0);
-	if (gc_bSounds.BoolValue)	
+	if (gc_bSounds.BoolValue)
 	{
 		EmitSoundToAllAny(g_sSoundFreezePath);
 	}
-	if (!gc_bStayOverlay.BoolValue)	
+	if (!gc_bStayOverlay.BoolValue)
 	{
 		CreateTimer( 3.0, DeleteOverlay, client );
 	}
@@ -786,10 +786,10 @@ void Setup_WallhackSkin(int client)
 	char sModel[PLATFORM_MAX_PATH];
 	GetClientModel(client, sModel, sizeof(sModel));
 	int iSkin = CPS_SetSkin(client, sModel, CPS_RENDER);
-	
+
 	if (iSkin == -1)
 		return;
-		
+
 	if (SDKHookEx(iSkin, SDKHook_SetTransmit, OnSetTransmit_Wallhack))
 		Setup_Wallhack(iSkin);
 }
@@ -799,18 +799,18 @@ void Setup_WallhackSkin(int client)
 void Setup_Wallhack(int iSkin)
 {
 	int iOffset;
-	
+
 	if (!iOffset && (iOffset = GetEntSendPropOffs(iSkin, "m_clrGlow")) == -1)
 		return;
-	
+
 	SetEntProp(iSkin, Prop_Send, "m_bShouldGlow", true, true);
 	SetEntProp(iSkin, Prop_Send, "m_nGlowStyle", 0);
 	SetEntPropFloat(iSkin, Prop_Send, "m_flGlowMaxDist", 10000000.0);
-	
+
 	int iRed = 60;
 	int iGreen = 60;
 	int iBlue = 200;
-	
+
 	SetEntData(iSkin, iOffset, iRed, _, true);
 	SetEntData(iSkin, iOffset + 1, iGreen, _, true);
 	SetEntData(iSkin, iOffset + 2, iBlue, _, true);
@@ -823,23 +823,23 @@ public Action OnSetTransmit_Wallhack(int iSkin, int client)
 {
 	if (!IsPlayerAlive(client))
 		return Plugin_Handled;
-	
+
 	LoopClients(target)
 	{
 		if (!CPS_HasSkin(target))
 			continue;
-		
+
 		if (!catched[target])
 			continue;
-		
+
 		if (EntRefToEntIndex(CPS_GetSkin(target)) != iSkin)
 			continue;
-			
+
 		if (GetClientTeam(client) == CS_TEAM_CT)
-		
+
 		return Plugin_Continue;
 	}
-	
+
 	return Plugin_Handled;
 }
 
@@ -883,9 +883,9 @@ public Action Timer_StartEvent(Handle timer)
 		}
 		return Plugin_Continue;
 	}
-	
+
 	g_iFreezeTime = gc_iFreezeTime.IntValue;
-	
+
 	if (g_iRound > 0)
 	{
 		LoopClients(client) if (IsPlayerAlive(client))
@@ -895,7 +895,7 @@ public Action Timer_StartEvent(Handle timer)
 				SetEntityMoveType(client, MOVETYPE_WALK);
 				SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", 1.4);
 			}
-			
+
 			PrintCenterText(client, "%t", "catch_start_nc");
 			if (gc_bOverlays.BoolValue) ShowOverlay(client, g_sOverlayStartPath, 2.0);
 			if (gc_bSounds.BoolValue)
@@ -907,7 +907,7 @@ public Action Timer_StartEvent(Handle timer)
 		CPrintToChatAll("%t %t", "catch_tag" , "catch_start");
 	}
 	FreezeTimer = null;
-	
+
 	return Plugin_Stop;
 }
 
@@ -951,7 +951,7 @@ void CreateInfoPanel(int client)
 	DrawPanelText(CatchMenu, info);
 	DrawPanelText(CatchMenu, "-----------------------------------");
 	Format(info, sizeof(info), "%T", "warden_close", client);
-	DrawPanelItem(CatchMenu, info); 
+	DrawPanelItem(CatchMenu, info);
 	SendPanelToClient(CatchMenu, client, Handler_NullCancel, 20);
 }
 
@@ -1029,8 +1029,8 @@ public Action ResetSprint(int client)
 public Action Timer_SprintEnd(Handle timer, any client)
 {
 	SprintTimer[client] = null;
-	
-	
+
+
 	if (IsClientInGame(client) && (ClientSprintStatus[client] & IsSprintUsing))
 	{
 		SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", 1.0);

--- a/addons/sourcemod/scripting/MyJailbreak/catch.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/catch.sp
@@ -488,6 +488,8 @@ public void Event_RoundStart(Event event, char[] name, bool dontBroadcast)
 		{
 			g_iCoolDown -= 1;
 		}
+
+		return;
 	}
 
 	SetCvar("sm_hosties_lr", 0);

--- a/addons/sourcemod/scripting/MyJailbreak/catch.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/catch.sp
@@ -206,7 +206,7 @@ public void OnPluginStart()
 	SetLogFile(g_sEventsLogFile, "Events", "MyJailbreak");
 
 	// Offsets
-    g_iCollision_Offset = FindSendPropInfo("CBaseEntity", "m_CollisionGroup");
+	g_iCollision_Offset = FindSendPropInfo("CBaseEntity", "m_CollisionGroup");
 }
 
 
@@ -996,10 +996,12 @@ void UnhookWallhack(int client)
 {
 	if (IsValidClient(client, false, true))
 	{
-		// char sModel[PLATFORM_MAX_PATH];
-		// GetClientModel(client, sModel, sizeof(sModel));
-		// SetEntProp(client, Prop_Send, "m_bShouldGlow", false, true);
-		SDKUnhook(client, SDKHook_SetTransmit, OnSetTransmit_Wallhack);
+		int iSkin = CPS_GetSkin(client);
+		if (iSkin != INVALID_ENT_REFERENCE)
+		{
+			SetEntProp(client, Prop_Send, "m_bShouldGlow", false, true);
+			SDKUnhook(iSkin, SDKHook_SetTransmit, OnSetTransmit_Wallhack);
+		}
 	}
 }
 

--- a/addons/sourcemod/scripting/MyJailbreak/catch.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/catch.sp
@@ -98,6 +98,7 @@ int g_iCatchCounter[MAXPLAYERS+1];
 int g_iMaxRound;
 int g_iFreezeTime;
 int g_iTsLR;
+int g_iCollision_Offset;
 
 // Handles
 Handle g_hSprintTimer[MAXPLAYERS+1];
@@ -203,6 +204,9 @@ public void OnPluginStart()
 
 	// Logs
 	SetLogFile(g_sEventsLogFile, "Events", "MyJailbreak");
+
+	// Offsets
+    g_iCollision_Offset = FindSendPropInfo("CBaseEntity", "m_CollisionGroup");
 }
 
 
@@ -516,7 +520,7 @@ public void Event_RoundStart(Event event, char[] name, bool dontBroadcast)
 			StripAllPlayerWeapons(client);
 			GivePlayerItem(client, "weapon_knife");
 
-			SetEntData(client, FindSendPropInfo("CBaseEntity", "m_CollisionGroup"), 2, 4, true);
+			SetEntData(client, g_iCollision_Offset, 2, 4, true);
 			SendPanelToClient(g_hCatchMenu, client, Handler_NullCancel, 20);
 			PrintCenterText(client, "%t", "catch_start_nc");
 
@@ -554,7 +558,7 @@ public void Event_RoundEnd(Event event, char[] name, bool dontBroadcast)
 	{
 		LoopValidClients(client, true, true)
 		{
-			SetEntData(client, FindSendPropInfo("CBaseEntity", "m_CollisionGroup"), 0, 4, true);
+			SetEntData(client, g_iCollision_Offset, 0, 4, true);
 
 			CreateTimer(0.0, DeleteOverlay, client);
 			SetEntityRenderColor(client, 255, 255, 255, 0);
@@ -773,7 +777,7 @@ public void OnAvailableLR(int Announced)
 			ClientSprintStatus[client] = 0;
 			g_bCatched[client] = false;
 
-			SetEntData(client, FindSendPropInfo("CBaseEntity", "m_CollisionGroup"), 0, 4, true);
+			SetEntData(client, g_iCollision_Offset, 0, 4, true);
 
 			CreateTimer(0.0, DeleteOverlay, client);
 

--- a/addons/sourcemod/scripting/MyJailbreak/catch.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/catch.sp
@@ -156,7 +156,7 @@ public void OnPluginStart()
 	gc_bSetA = AutoExecConfig_CreateConVar("sm_catch_admin", "1", "0 - disabled, 1 - allow admin/vip to set catch round", _, true, 0.0, true, 1.0);
 	gc_sAdminFlag = AutoExecConfig_CreateConVar("sm_catch_flag", "g", "Set flag for admin/vip to set this Event Day.");
 	gc_bVote = AutoExecConfig_CreateConVar("sm_catch_vote", "1", "0 - disabled, 1 - allow player to vote for catch", _, true, 0.0, true, 1.0);
-	gc_iCatchCount = AutoExecConfig_CreateConVar("sm_catch_count", "0", "How many times a terror can be catched before he get killed. 0 = T dont get killed ever all T must be g_bCatched", _, true, 0.0);
+	gc_iCatchCount = AutoExecConfig_CreateConVar("sm_catch_count", "0", "How many times a terror can be catched before he get killed. 0 = T dont get killed ever all T must be catched", _, true, 0.0);
 	gc_fBeaconTime = AutoExecConfig_CreateConVar("sm_catch_beacon_time", "240", "Time in seconds until the beacon turned on (set to 0 to disable)", _, true, 0.0);
 	gc_bWallhack = AutoExecConfig_CreateConVar("sm_catch_wallhack", "1", "0 - disabled, 1 - enable wallhack for CT to see freezed enemeys", _, true,  0.0, true, 1.0);
 	gc_iRounds = AutoExecConfig_CreateConVar("sm_catch_rounds", "1", "Rounds to play in a row", _, true, 1.0);

--- a/addons/sourcemod/scripting/MyJailbreak/catch.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/catch.sp
@@ -48,6 +48,7 @@
 #define IsSprintCoolDown (1 << 1)
 
 // Booleans
+bool g_bIsLateLoad = false;
 bool g_bIsCatch = false;
 bool g_bStartCatch = false;
 bool g_bCatched[MAXPLAYERS+1] = { false, ... };
@@ -125,6 +126,12 @@ public Plugin myinfo = {
 	url = MYJB_URL_LINK
 };
 
+public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
+{
+	g_bIsLateLoad = late;
+
+	return APLRes_Success;
+}
 // Start
 public void OnPluginStart()
 {
@@ -207,6 +214,15 @@ public void OnPluginStart()
 
 	// Offsets
 	g_iCollision_Offset = FindSendPropInfo("CBaseEntity", "m_CollisionGroup");
+
+	// Late loading
+	if (g_bIsLateLoad)
+	{
+		LoopClients(client)
+		{
+			OnClientPutInServer(client);
+		}
+	}
 }
 
 
@@ -1134,7 +1150,7 @@ public Action Command_StartSprint(int client, int args)
 		return Plugin_Handled;
 	}
 
-	if (gc_bSprint.BoolValue || GetClientTeam(client) != CS_TEAM_T || g_bCatched[client])
+	if (!gc_bSprint.BoolValue || GetClientTeam(client) != CS_TEAM_T || g_bCatched[client])
 	{
 		return Plugin_Handled;
 	}

--- a/addons/sourcemod/scripting/MyJailbreak/catch.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/catch.sp
@@ -974,19 +974,14 @@ void Setup_Wallhack(int iSkin)
 // Who can see wallhack if vaild
 public Action OnSetTransmit_Wallhack(int iSkin, int client)
 {
-	if (!IsPlayerAlive(client))
+	if (!IsPlayerAlive(client) || GetClientTeam(client) != CS_TEAM_CT)
 	{
 		return Plugin_Handled;
 	}
 
 	LoopClients(target)
 	{
-		if (!CPS_HasSkin(target))
-		{
-			continue;
-		}
-
-		if (!g_bCatched[target])
+		if (!CPS_HasSkin(target) || !g_bCatched[target])
 		{
 			continue;
 		}
@@ -996,10 +991,7 @@ public Action OnSetTransmit_Wallhack(int iSkin, int client)
 			continue;
 		}
 
-		if (GetClientTeam(client) == CS_TEAM_CT) // Something wrong here
-		{
-			return Plugin_Continue;
-		}
+		return Plugin_Continue;
 	}
 
 	return Plugin_Handled;
@@ -1014,7 +1006,7 @@ void UnhookWallhack(int client)
 		int iSkin = CPS_GetSkin(client);
 		if (iSkin != INVALID_ENT_REFERENCE)
 		{
-			SetEntProp(client, Prop_Send, "m_bShouldGlow", false, true);
+			SetEntProp(iSkin, Prop_Send, "m_bShouldGlow", false, true);
 			SDKUnhook(iSkin, SDKHook_SetTransmit, OnSetTransmit_Wallhack);
 		}
 	}

--- a/addons/sourcemod/scripting/MyJailbreak/catch.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/catch.sp
@@ -22,9 +22,7 @@
 /******************************************************************************
                    STARTUP
 ******************************************************************************/
-
-
-//Includes
+// Includes
 #include <sourcemod>
 #include <sdktools>
 #include <sdkhooks>
@@ -41,24 +39,20 @@
 
 #include <CustomPlayerSkins>
 
-
-//Compiler Options
+// Compiler Options
 #pragma semicolon 1
 #pragma newdecls required
 
+// Defines
+#define IsSprintUsing    (1 << 0)
+#define IsSprintCoolDown (1 << 1)
 
-//Defines
-#define IsSprintUsing   (1<<0)
-#define IsSprintCoolDown  (1<<1)
+// Booleans
+bool g_bIsCatch = false;
+bool g_bStartCatch = false;
+bool g_bCatched[MAXPLAYERS+1] = { false, ... };
 
-
-//Booleans
-bool IsCatch;
-bool StartCatch;
-bool catched[MAXPLAYERS+1];
-
-
-//Console Variables
+// Console Variables
 ConVar gc_bPlugin;
 ConVar gc_bSetW;
 ConVar gc_bSetA;
@@ -90,13 +84,11 @@ ConVar gc_sAdminFlag;
 ConVar gc_iCatchCount;
 ConVar gc_bAllowLR;
 
-
-//Extern Convars
+// Extern Convars
 ConVar g_iMPRoundTime;
 ConVar g_iTerrorForLR;
 
-
-//Integers
+// Integers
 int g_iVoteCount;
 int g_iOldRoundTime;
 int g_iCoolDown;
@@ -107,15 +99,13 @@ int g_iMaxRound;
 int g_iFreezeTime;
 int g_iTsLR;
 
+// Handles
+Handle g_hSprintTimer[MAXPLAYERS+1];
+Handle g_hCatchMenu;
+Handle g_hFreezeTimer;
+Handle g_hBeaconTimer;
 
-//Handles
-Handle SprintTimer[MAXPLAYERS+1];
-Handle CatchMenu;
-Handle FreezeTimer;
-Handle BeaconTimer;
-
-
-//Strings
+// Strings
 char g_sSoundUnFreezePath[256];
 char g_sSoundFreezePath[256];
 char g_sHasVoted[1500];
@@ -125,8 +115,7 @@ char g_sAdminFlag[32];
 char g_sSoundStartPath[256];
 char g_sOverlayStartPath[256];
 
-
-//Info
+// Info
 public Plugin myinfo = {
 	name = "MyJailbreak - Catch & Freeze",
 	author = "shanapu",
@@ -135,22 +124,19 @@ public Plugin myinfo = {
 	url = MYJB_URL_LINK
 };
 
-
-//Start
+// Start
 public void OnPluginStart()
 {
 	// Translation
 	LoadTranslations("MyJailbreak.Warden.phrases");
 	LoadTranslations("MyJailbreak.Catch.phrases");
 
-
-	//Client Commands
+	// Client Commands
 	RegConsoleCmd("sm_setcatch", Command_SetCatch, "Allows the Admin or Warden to set catch as next round");
 	RegConsoleCmd("sm_catch", Command_VoteCatch, "Allows players to vote for a catch ");
 	RegConsoleCmd("sm_sprint", Command_StartSprint, "Start sprinting!");
 
-
-	//AutoExecConfig
+	// AutoExecConfig
 	AutoExecConfig_SetFile("Catch", "MyJailbreak/EventDays");
 	AutoExecConfig_SetCreateFile(true);
 
@@ -162,7 +148,7 @@ public void OnPluginStart()
 	gc_bSetA = AutoExecConfig_CreateConVar("sm_catch_admin", "1", "0 - disabled, 1 - allow admin/vip to set catch round", _, true, 0.0, true, 1.0);
 	gc_sAdminFlag = AutoExecConfig_CreateConVar("sm_catch_flag", "g", "Set flag for admin/vip to set this Event Day.");
 	gc_bVote = AutoExecConfig_CreateConVar("sm_catch_vote", "1", "0 - disabled, 1 - allow player to vote for catch", _, true, 0.0, true, 1.0);
-	gc_iCatchCount = AutoExecConfig_CreateConVar("sm_catch_count", "0", "How many times a terror can be catched before he get killed. 0 = T dont get killed ever all T must be catched", _, true, 0.0);
+	gc_iCatchCount = AutoExecConfig_CreateConVar("sm_catch_count", "0", "How many times a terror can be g_bCatched before he get killed. 0 = T dont get killed ever all T must be g_bCatched", _, true, 0.0);
 	gc_fBeaconTime = AutoExecConfig_CreateConVar("sm_catch_beacon_time", "240", "Time in seconds until the beacon turned on (set to 0 to disable)", _, true, 0.0);
 	gc_bWallhack = AutoExecConfig_CreateConVar("sm_catch_wallhack", "1", "0 - disabled, 1 - enable wallhack for CT to see freezed enemeys", _, true,  0.0, true, 1.0);
 	gc_iRounds = AutoExecConfig_CreateConVar("sm_catch_rounds", "1", "Rounds to play in a row", _, true, 1.0);
@@ -171,9 +157,9 @@ public void OnPluginStart()
 	gc_iCooldownStart = AutoExecConfig_CreateConVar("sm_catch_cooldown_start", "3", "Rounds until event can be start after mapchange.", _, true, 0.0);
 	gc_bSetABypassCooldown = AutoExecConfig_CreateConVar("sm_catch_cooldown_admin", "1", "0 - disabled, 1 - ignore the cooldown when admin/vip set catch round", _, true, 0.0, true, 1.0);
 	gc_bOverlays = AutoExecConfig_CreateConVar("sm_catch_overlays_enable", "1", "0 - disabled, 1 - enable overlays", _, true, 0.0, true, 1.0);
-	gc_sOverlayStartPath = AutoExecConfig_CreateConVar("sm_catch_overlays_start", "overlays/MyJailbreak/start" , "Path to the start Overlay DONT TYPE .vmt or .vft");
-	gc_sOverlayFreeze = AutoExecConfig_CreateConVar("sm_catch_overlayfreeze_path", "overlays/MyJailbreak/frozen" , "Path to the Freeze Overlay DONT TYPE .vmt or .vft");
-	gc_bStayOverlay = AutoExecConfig_CreateConVar("sm_catch_stayoverlay", "1", "0 - overlays will removed after 3sec. , 1 - overlays will stay until unfreeze", _, true, 0.0, true, 1.0);
+	gc_sOverlayStartPath = AutoExecConfig_CreateConVar("sm_catch_overlays_start", "overlays/MyJailbreak/start", "Path to the start Overlay DONT TYPE .vmt or .vft");
+	gc_sOverlayFreeze = AutoExecConfig_CreateConVar("sm_catch_overlayfreeze_path", "overlays/MyJailbreak/frozen", "Path to the Freeze Overlay DONT TYPE .vmt or .vft");
+	gc_bStayOverlay = AutoExecConfig_CreateConVar("sm_catch_stayoverlay", "1", "0 - overlays will removed after 3sec., 1 - overlays will stay until unfreeze", _, true, 0.0, true, 1.0);
 	gc_iFreezeTime = AutoExecConfig_CreateConVar("sm_catch_freezetime", "15", "Time in seconds CTs are freezed", _, true, 0.0);
 	gc_bSounds = AutoExecConfig_CreateConVar("sm_catch_sounds_enable", "1", "0 - disabled, 1 - enable sounds ", _, true, 0.0, true, 1.0);
 	gc_sSoundStartPath = AutoExecConfig_CreateConVar("sm_catch_sounds_start", "music/MyJailbreak/start.mp3", "Path to the soundfile which should be played for a start.");
@@ -184,18 +170,11 @@ public void OnPluginStart()
 	gc_iSprintCooldown= AutoExecConfig_CreateConVar("sm_catch_sprint_cooldown", "10", "Time in seconds the player must wait for the next sprint", _, true, 0.0);
 	gc_fSprintSpeed = AutoExecConfig_CreateConVar("sm_catch_sprint_speed", "1.25", "Ratio for how fast the player will sprint", _, true, 1.01);
 	gc_fSprintTime = AutoExecConfig_CreateConVar("sm_catch_sprint_time", "3.0", "Time in seconds the player will sprint", _, true, 1.0);
-	gc_bAllowLR = AutoExecConfig_CreateConVar("sm_catch_allow_lr", "0" , "0 - disabled, 1 - enable LR for last round and end eventday", _, true, 0.0, true, 1.0);
+	gc_bAllowLR = AutoExecConfig_CreateConVar("sm_catch_allow_lr", "0", "0 - disabled, 1 - enable LR for last round and end eventday", _, true, 0.0, true, 1.0);
 
 	AutoExecConfig_ExecuteFile();
 	AutoExecConfig_CleanFile();
 
-
-	//Hooks
-	HookEvent("round_start", Event_RoundStart);
-	HookEvent("player_spawn", Event_PlayerSpawn);
-	HookEvent("round_end", Event_RoundEnd);
-	HookEvent("player_team", Event_PlayerTeam);
-	HookEvent("player_death", Event_PlayerTeam);
 	HookConVarChange(gc_sOverlayStartPath, OnSettingChanged);
 	HookConVarChange(gc_sSoundStartPath, OnSettingChanged);
 	HookConVarChange(gc_sOverlayFreeze, OnSettingChanged);
@@ -203,30 +182,40 @@ public void OnPluginStart()
 	HookConVarChange(gc_sSoundUnFreezePath, OnSettingChanged);
 	HookConVarChange(gc_sAdminFlag, OnSettingChanged);
 
+	// Hooks
+	HookEvent("round_start", Event_RoundStart);
+	HookEvent("player_spawn", Event_PlayerSpawn);
+	HookEvent("round_end", Event_RoundEnd);
+	HookEvent("player_team", Event_PlayerTeam);
+	HookEvent("player_death", Event_PlayerTeam);
 
-	//FindConVar
+	// FindConVar
 	g_iMaxRound = gc_iRounds.IntValue;
 	g_iCoolDown = gc_iCooldownDay.IntValue + 1;
 	g_iFreezeTime = gc_iFreezeTime.IntValue;
 	g_iMPRoundTime = FindConVar("mp_roundtime");
-	gc_sOverlayStartPath.GetString(g_sOverlayStartPath , sizeof(g_sOverlayStartPath));
+	gc_sOverlayStartPath.GetString(g_sOverlayStartPath, sizeof(g_sOverlayStartPath));
 	gc_sSoundStartPath.GetString(g_sSoundStartPath, sizeof(g_sSoundStartPath));
 	gc_sSoundFreezePath.GetString(g_sSoundFreezePath, sizeof(g_sSoundFreezePath));
 	gc_sSoundUnFreezePath.GetString(g_sSoundUnFreezePath, sizeof(g_sSoundUnFreezePath));
-	gc_sOverlayFreeze.GetString(g_sOverlayFreeze , sizeof(g_sOverlayFreeze));
-	gc_sAdminFlag.GetString(g_sAdminFlag , sizeof(g_sAdminFlag));
+	gc_sOverlayFreeze.GetString(g_sOverlayFreeze, sizeof(g_sOverlayFreeze));
+	gc_sAdminFlag.GetString(g_sAdminFlag, sizeof(g_sAdminFlag));
 
+	// Logs
 	SetLogFile(g_sEventsLogFile, "Events", "MyJailbreak");
 }
 
 
-//ConVarChange for Strings
+// ConVarChange for Strings
 public void OnSettingChanged(Handle convar, const char[] oldValue, const char[] newValue)
 {
 	if (convar == gc_sSoundFreezePath)
 	{
 		strcopy(g_sSoundFreezePath, sizeof(g_sSoundFreezePath), newValue);
-		if (gc_bSounds.BoolValue) PrecacheSoundAnyDownload(g_sSoundFreezePath);
+		if (gc_bSounds.BoolValue)
+		{
+			PrecacheSoundAnyDownload(g_sSoundFreezePath);
+		}
 	}
 	else if (convar == gc_sAdminFlag)
 	{
@@ -235,41 +224,53 @@ public void OnSettingChanged(Handle convar, const char[] oldValue, const char[] 
 	else if (convar == gc_sSoundUnFreezePath)
 	{
 		strcopy(g_sSoundUnFreezePath, sizeof(g_sSoundUnFreezePath), newValue);
-		if (gc_bSounds.BoolValue) PrecacheSoundAnyDownload(g_sSoundUnFreezePath);
+		if (gc_bSounds.BoolValue)
+		{
+			PrecacheSoundAnyDownload(g_sSoundUnFreezePath);
+		}
 	}
 	else if (convar == gc_sOverlayFreeze)
 	{
 		strcopy(g_sOverlayFreeze, sizeof(g_sOverlayFreeze), newValue);
-		if (gc_bOverlays.BoolValue) PrecacheDecalAnyDownload(g_sOverlayFreeze);
+		if (gc_bOverlays.BoolValue)
+		{
+			PrecacheDecalAnyDownload(g_sOverlayFreeze);
+		}
 	}
 	else if (convar == gc_sSoundStartPath)
 	{
 		strcopy(g_sSoundStartPath, sizeof(g_sSoundStartPath), newValue);
-		if (gc_bSounds.BoolValue) PrecacheSoundAnyDownload(g_sSoundStartPath);
+		if (gc_bSounds.BoolValue)
+		{
+			PrecacheSoundAnyDownload(g_sSoundStartPath);
+		}
 	}
 	else if (convar == gc_sOverlayStartPath)
 	{
 		strcopy(g_sOverlayStartPath, sizeof(g_sOverlayStartPath), newValue);
-		if (gc_bOverlays.BoolValue) PrecacheDecalAnyDownload(g_sOverlayStartPath);
+		if (gc_bOverlays.BoolValue)
+		{
+			PrecacheDecalAnyDownload(g_sOverlayStartPath);
+		}
 	}
 }
 
 
-//Initialize Plugin
+// Initialize Plugin
 public void OnConfigsExecuted()
 {
 	g_iFreezeTime = gc_iFreezeTime.IntValue;
 	g_iCoolDown = gc_iCooldownStart.IntValue + 1;
 	g_iMaxRound = gc_iRounds.IntValue;
 
-	//FindConVar
+	// FindConVar
 	g_iTerrorForLR = FindConVar("sm_hosties_lr_ts_max");
 
-	//Set custom Commands
+	// Set custom Commands
 	int iCount = 0;
 	char sCommands[128], sCommandsL[12][32], sCommand[32];
 
-	//Vote
+	// Vote
 	gc_sCustomCommandVote.GetString(sCommands, sizeof(sCommands));
 	ReplaceString(sCommands, sizeof(sCommands), " ", "");
 	iCount = ExplodeString(sCommands, ",", sCommandsL, sizeof(sCommandsL), sizeof(sCommandsL[]));
@@ -277,11 +278,13 @@ public void OnConfigsExecuted()
 	for (int i = 0; i < iCount; i++)
 	{
 		Format(sCommand, sizeof(sCommand), "sm_%s", sCommandsL[i]);
-		if (GetCommandFlags(sCommand) == INVALID_FCVAR_FLAGS)  //if command not already exist
+		if (GetCommandFlags(sCommand) == INVALID_FCVAR_FLAGS) // if command not already exist
+		{
 			RegConsoleCmd(sCommand, Command_VoteCatch, "Allows players to vote for a catch ");
+		}
 	}
 
-	//Set
+	// Set
 	gc_sCustomCommandSet.GetString(sCommands, sizeof(sCommands));
 	ReplaceString(sCommands, sizeof(sCommands), " ", "");
 	iCount = ExplodeString(sCommands, ",", sCommandsL, sizeof(sCommandsL), sizeof(sCommandsL[]));
@@ -289,191 +292,186 @@ public void OnConfigsExecuted()
 	for (int i = 0; i < iCount; i++)
 	{
 		Format(sCommand, sizeof(sCommand), "sm_%s", sCommandsL[i]);
-		if (GetCommandFlags(sCommand) == INVALID_FCVAR_FLAGS)  //if command not already exist
+		if (GetCommandFlags(sCommand) == INVALID_FCVAR_FLAGS) // if command not already exist
+		{
 			RegConsoleCmd(sCommand, Command_SetCatch, "Allows the Admin or Warden to set catch as next round");
+		}
 	}
 }
-
 
 /******************************************************************************
                    COMMANDS
 ******************************************************************************/
-
-
-//Admin & Warden set Event
+// Admin & Warden set Event
 public Action Command_SetCatch(int client, int args)
 {
-	if (gc_bPlugin.BoolValue)
+	if (!gc_bPlugin.BoolValue)
 	{
-		if (client == 0)
-		{
-			StartNextRound();
-			if (MyJailbreak_ActiveLogging()) LogToFileEx(g_sEventsLogFile, "Event Catch was started by groupvoting");
-		}
-		else if (warden_iswarden(client))
-		{
-			if (gc_bSetW.BoolValue)
-			{
-				if ((GetTeamClientCount(CS_TEAM_CT) > 0) && (GetTeamClientCount(CS_TEAM_T) > 0 ))
-				{
-					char EventDay[64];
-					MyJailbreak_GetEventDayName(EventDay);
-
-					if (StrEqual(EventDay, "none", false))
-					{
-						if (g_iCoolDown == 0)
-						{
-							StartNextRound();
-							if (MyJailbreak_ActiveLogging()) LogToFileEx(g_sEventsLogFile, "Event Catch was started by warden %L", client);
-						}
-						else CReplyToCommand(client, "%t %t", "catch_tag" , "catch_wait", g_iCoolDown);
-					}
-					else CReplyToCommand(client, "%t %t", "catch_tag" , "catch_progress" , EventDay);
-				}
-				else CReplyToCommand(client, "%t %t", "catch_tag" , "catch_minplayer");
-			}
-			else CReplyToCommand(client, "%t %t", "warden_tag" , "catch_setbywarden");
-		}
-		else if (CheckVipFlag(client, g_sAdminFlag))
-			{
-				if (gc_bSetA.BoolValue)
-				{
-					if ((GetTeamClientCount(CS_TEAM_CT) > 0) && (GetTeamClientCount(CS_TEAM_T) > 0 ))
-					{
-						char EventDay[64];
-						MyJailbreak_GetEventDayName(EventDay);
-
-						if (StrEqual(EventDay, "none", false))
-						{
-							if ((g_iCoolDown == 0) || gc_bSetABypassCooldown.BoolValue)
-							{
-								StartNextRound();
-								if (MyJailbreak_ActiveLogging()) LogToFileEx(g_sEventsLogFile, "Event Catch was started by admin %L", client);
-							}
-							else CReplyToCommand(client, "%t %t", "catch_tag" , "catch_wait", g_iCoolDown);
-						}
-						else CReplyToCommand(client, "%t %t", "catch_tag" , "catch_progress" , EventDay);
-					}
-					else CReplyToCommand(client, "%t %t", "catch_tag" , "catch_minplayer");
-				}
-				else CReplyToCommand(client, "%t %t", "catch_tag" , "catch_setbyadmin");
-			}
-			else CReplyToCommand(client, "%t %t", "warden_tag" , "warden_notwarden");
+		CReplyToCommand(client, "%t %t", "catch_tag", "catch_disabled");
+		return Plugin_Handled;
 	}
-	else CReplyToCommand(client, "%t %t", "catch_tag" , "catch_disabled");
+
+	if (client == 0) // Called by a server/voting
+	{
+		StartNextRound();
+		if (MyJailbreak_ActiveLogging())
+		{
+			LogToFileEx(g_sEventsLogFile, "Event Catch was started by groupvoting");
+		}
+	}
+	else if (warden_iswarden(client)) // Called by warden
+	{
+		if (!gc_bSetW.BoolValue)
+		{
+			CReplyToCommand(client, "%t %t", "warden_tag", "catch_setbywarden");
+			return Plugin_Handled;
+		}
+
+		if (GetTeamClientCount(CS_TEAM_CT) == 0 || GetTeamClientCount(CS_TEAM_T) == 0)
+		{
+			CReplyToCommand(client, "%t %t", "catch_tag", "catch_minplayer");
+			return Plugin_Handled;
+		}
+
+		char EventDay[64];
+		MyJailbreak_GetEventDayName(EventDay);
+
+		if (!StrEqual(EventDay, "none", false))
+		{
+			CReplyToCommand(client, "%t %t", "catch_tag", "catch_progress", EventDay);
+			return Plugin_Handled;
+		}
+
+		if (g_iCoolDown > 0)
+		{
+			CReplyToCommand(client, "%t %t", "catch_tag", "catch_wait", g_iCoolDown);
+			return Plugin_Handled;
+		}
+
+		StartNextRound();
+		if (MyJailbreak_ActiveLogging())
+		{
+			LogToFileEx(g_sEventsLogFile, "Event Catch was started by warden %L", client);
+		}
+	}
+	else if (CheckVipFlag(client, g_sAdminFlag)) // Called by admin/VIP
+	{
+		if (!gc_bSetA.BoolValue)
+		{
+			CReplyToCommand(client, "%t %t", "warden_tag", "catch_setbyadmin");
+			return Plugin_Handled;
+		}
+
+		if (GetTeamClientCount(CS_TEAM_CT) == 0 || GetTeamClientCount(CS_TEAM_T) == 0)
+		{
+			CReplyToCommand(client, "%t %t", "catch_tag", "catch_minplayer");
+			return Plugin_Handled;
+		}
+
+		char EventDay[64];
+		MyJailbreak_GetEventDayName(EventDay);
+
+		if (!StrEqual(EventDay, "none", false))
+		{
+			CReplyToCommand(client, "%t %t", "catch_tag", "catch_progress", EventDay);
+			return Plugin_Handled;
+		}
+
+		if (g_iCoolDown > 0 && !gc_bSetABypassCooldown.BoolValue)
+		{
+			CReplyToCommand(client, "%t %t", "catch_tag", "catch_wait", g_iCoolDown);
+			return Plugin_Handled;
+		}
+
+		StartNextRound();
+		if (MyJailbreak_ActiveLogging())
+		{
+			LogToFileEx(g_sEventsLogFile, "Event Catch was started by admin %L", client);
+		}
+	}
+	else
+	{
+		CReplyToCommand(client, "%t %t", "warden_tag", "warden_notwarden");
+	}
+
 	return Plugin_Handled;
 }
 
 
-//Voting for Event
+// Voting for Event
 public Action Command_VoteCatch(int client, int args)
 {
+	if (!gc_bPlugin.BoolValue)
+	{
+		CReplyToCommand(client, "%t %t", "catch_tag", "catch_disabled");
+		return Plugin_Handled;
+	}
+
+	if (!gc_bVote.BoolValue)
+	{
+		CReplyToCommand(client, "%t %t", "catch_tag", "catch_voting");
+		return Plugin_Handled;
+	}
+
+	if (GetTeamClientCount(CS_TEAM_CT) == 0 || GetTeamClientCount(CS_TEAM_T) == 0)
+	{
+		CReplyToCommand(client, "%t %t", "catch_tag", "catch_minplayer");
+		return Plugin_Handled;
+	}
+
+	char EventDay[64];
+	MyJailbreak_GetEventDayName(EventDay);
+
+	if (!StrEqual(EventDay, "none", false))
+	{
+		CReplyToCommand(client, "%t %t", "catch_tag", "catch_progress", EventDay);
+		return Plugin_Handled;
+	}
+
+	if (g_iCoolDown > 0)
+	{
+		CReplyToCommand(client, "%t %t", "catch_tag", "catch_wait", g_iCoolDown);
+		return Plugin_Handled;
+	}
+
 	char steamid[64];
 	GetClientAuthId(client, AuthId_Steam2, steamid, sizeof(steamid));
 
-	if (gc_bPlugin.BoolValue)
+	if (StrContains(g_sHasVoted, steamid, true) != -1)
 	{
-		if (gc_bVote.BoolValue)
-		{
-			if ((GetTeamClientCount(CS_TEAM_CT) > 0) && (GetTeamClientCount(CS_TEAM_T) > 0 ))
-			{
-				char EventDay[64];
-				MyJailbreak_GetEventDayName(EventDay);
-
-				if (StrEqual(EventDay, "none", false))
-				{
-					if (g_iCoolDown == 0)
-					{
-						if (StrContains(g_sHasVoted, steamid, true) == -1)
-						{
-							int playercount = (GetClientCount(true) / 2);
-							g_iVoteCount++;
-							int Missing = playercount - g_iVoteCount + 1;
-							Format(g_sHasVoted, sizeof(g_sHasVoted), "%s, %s", g_sHasVoted, steamid);
-
-							if (g_iVoteCount > playercount)
-							{
-								StartNextRound();
-								if (MyJailbreak_ActiveLogging()) LogToFileEx(g_sEventsLogFile, "Event Catch was started by voting");
-							}
-							else CPrintToChatAll("%t %t", "catch_tag" , "catch_need", Missing, client);
-						}
-						else CReplyToCommand(client, "%t %t", "catch_tag" , "catch_voted");
-					}
-					else CReplyToCommand(client, "%t %t", "catch_tag" , "catch_wait", g_iCoolDown);
-				}
-				else CReplyToCommand(client, "%t %t", "catch_tag" , "catch_progress" , EventDay);
-			}
-			else CReplyToCommand(client, "%t %t", "catch_tag" , "catch_minplayer");
-		}
-		else CReplyToCommand(client, "%t %t", "catch_tag" , "catch_voting");
+		CReplyToCommand(client, "%t %t", "catch_tag", "catch_voted");
+		return Plugin_Handled;
 	}
-	else CReplyToCommand(client, "%t %t", "catch_tag" , "catch_disabled");
+
+	int playercount = (GetClientCount(true) / 2);
+	g_iVoteCount += 1;
+
+	int Missing = playercount - g_iVoteCount + 1;
+	Format(g_sHasVoted, sizeof(g_sHasVoted), "%s, %s", g_sHasVoted, steamid);
+
+	if (g_iVoteCount > playercount)
+	{
+		StartNextRound();
+		if (MyJailbreak_ActiveLogging())
+		{
+			LogToFileEx(g_sEventsLogFile, "Event Catch was started by voting");
+		}
+	}
+	else
+	{
+		CPrintToChatAll("%t %t", "catch_tag", "catch_need", Missing, client);
+	}
+
 	return Plugin_Handled;
 }
-
 
 /******************************************************************************
                    EVENTS
 ******************************************************************************/
-
-
-//Round start
+// Round start
 public void Event_RoundStart(Event event, char[] name, bool dontBroadcast)
 {
-	if (StartCatch || IsCatch)
-	{
-		SetCvar("sm_hosties_lr", 0);
-		SetCvar("sm_warden_enable", 0);
-		SetCvar("sm_weapons_enable", 0);
-		MyJailbreak_SetEventDayPlanned(false);
-		MyJailbreak_SetEventDayRunning(true);
-		IsCatch = true;
-		g_iRound++;
-		StartCatch = false;
-		SJD_OpenDoors();
-
-		if (gc_fBeaconTime.FloatValue > 0.0) BeaconTimer = CreateTimer(gc_fBeaconTime.FloatValue, Timer_BeaconOn, TIMER_FLAG_NO_MAPCHANGE);
-
-		if (g_iRound > 0)
-			{
-				LoopClients(client)
-				{
-					CreateInfoPanel(client);
-					StripAllPlayerWeapons(client);
-					ClientSprintStatus[client] = 0;
-					GivePlayerItem(client, "weapon_knife");
-					SetEntData(client, FindSendPropInfo("CBaseEntity", "m_CollisionGroup"), 2, 4, true);
-					SendPanelToClient(CatchMenu, client, Handler_NullCancel, 20);
-					PrintCenterText(client, "%t", "catch_start_nc");
-
-					g_iCatchCounter[client] = 0;
-					catched[client] = false;
-
-					if (GetClientTeam(client) == CS_TEAM_CT)
-					{
-						SetEntityMoveType(client, MOVETYPE_NONE);
-						SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", 0.0);
-					}
-				}
-
-				//enable lr on last round
-				g_iTsLR = GetAliveTeamCount(CS_TEAM_T);
-
-				if (gc_bAllowLR.BoolValue)
-				{
-					if ((g_iRound == g_iMaxRound) && (g_iTsLR > g_iTerrorForLR.IntValue))
-					{
-						SetCvar("sm_hosties_lr", 1);
-					}
-				}
-
-				g_iFreezeTime--;
-				FreezeTimer = CreateTimer(1.0, Timer_StartEvent, _, TIMER_REPEAT);
-				CPrintToChatAll("%t %t", "catch_tag" , "catch_rounds", g_iRound, g_iMaxRound);
-			}
-	}
-	else
+	if (!g_bStartCatch && !g_bIsCatch)
 	{
 		char EventDay[64];
 		MyJailbreak_GetEventDayName(EventDay);
@@ -482,57 +480,137 @@ public void Event_RoundStart(Event event, char[] name, bool dontBroadcast)
 		{
 			g_iCoolDown = gc_iCooldownDay.IntValue + 1;
 		}
-		else if (g_iCoolDown > 0) g_iCoolDown--;
+		else if (g_iCoolDown > 0)
+		{
+			g_iCoolDown -= 1;
+		}
+	}
+
+	SetCvar("sm_hosties_lr", 0);
+	SetCvar("sm_warden_enable", 0);
+	SetCvar("sm_weapons_enable", 0);
+	MyJailbreak_SetEventDayPlanned(false);
+	MyJailbreak_SetEventDayRunning(true);
+
+	g_bIsCatch = true;
+	g_iRound += 1;
+	g_bStartCatch = false;
+
+	SJD_OpenDoors();
+
+	if (gc_fBeaconTime.FloatValue > 0.0)
+	{
+		g_hBeaconTimer = CreateTimer(gc_fBeaconTime.FloatValue, Timer_BeaconOn, TIMER_FLAG_NO_MAPCHANGE);
+	}
+
+	if (g_iRound > 0)
+	{
+		LoopClients(client)
+		{
+			ClientSprintStatus[client] = 0;
+			g_iCatchCounter[client] = 0;
+			g_bCatched[client] = false;
+
+			CreateInfoPanel(client);
+			StripAllPlayerWeapons(client);
+
+			GivePlayerItem(client, "weapon_knife");
+			SetEntData(client, FindSendPropInfo("CBaseEntity", "m_CollisionGroup"), 2, 4, true);
+			SendPanelToClient(g_hCatchMenu, client, Handler_NullCancel, 20);
+			PrintCenterText(client, "%t", "catch_start_nc");
+
+			if (GetClientTeam(client) == CS_TEAM_CT)
+			{
+				SetEntityMoveType(client, MOVETYPE_NONE);
+				SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", 0.0);
+			}
+		}
+
+		// enable lr on last round
+		g_iTsLR = GetAliveTeamCount(CS_TEAM_T);
+
+		if (gc_bAllowLR.BoolValue)
+		{
+			if (g_iRound == g_iMaxRound && g_iTsLR > g_iTerrorForLR.IntValue)
+			{
+				SetCvar("sm_hosties_lr", 1);
+			}
+		}
+
+		g_iFreezeTime -= 1;
+		g_hFreezeTimer = CreateTimer(1.0, Timer_StartEvent, _, TIMER_REPEAT);
+		CPrintToChatAll("%t %t", "catch_tag", "catch_rounds", g_iRound, g_iMaxRound);
 	}
 }
 
-
-//Round End
+// Round End
 public void Event_RoundEnd(Event event, char[] name, bool dontBroadcast)
 {
 	int winner = event.GetInt("winner");
 
-	if (IsCatch)
+	if (g_bIsCatch)
 	{
 		LoopValidClients(client, true, true)
 		{
 			SetEntData(client, FindSendPropInfo("CBaseEntity", "m_CollisionGroup"), 0, 4, true);
-			ClientSprintStatus[client] = 0;
-			CreateTimer( 0.0, DeleteOverlay, client );
+
+			CreateTimer(0.0, DeleteOverlay, client);
 			SetEntityRenderColor(client, 255, 255, 255, 0);
-			catched[client] = false;
+
+			ClientSprintStatus[client] = 0;
+			g_bCatched[client] = false;
+
 			if (GetClientTeam(client) == CS_TEAM_T)
 			{
 				StripAllPlayerWeapons(client);
 			}
-			if (gc_bWallhack.BoolValue) UnhookWallhack(client);
+
+			if (gc_bWallhack.BoolValue)
+			{
+				UnhookWallhack(client);
+			}
 		}
 
-		delete FreezeTimer;
-		delete BeaconTimer;
+		delete g_hFreezeTimer;
+		delete g_hBeaconTimer;
 
-		if (winner == 2) PrintCenterTextAll("%t", "catch_twin_nc");
-		if (winner == 3) PrintCenterTextAll("%t", "catch_ctwin_nc");
+		if (winner == 2)
+		{
+			PrintCenterTextAll("%t", "catch_twin_nc");
+		}
+
+		if (winner == 3)
+		{
+			PrintCenterTextAll("%t", "catch_ctwin_nc");
+		}
+
 		if (g_iRound == g_iMaxRound)
 		{
-			IsCatch = false;
+			g_bIsCatch = false;
 			g_iRound = 0;
 			Format(g_sHasVoted, sizeof(g_sHasVoted), "");
+
 			SetCvar("sm_hosties_lr", 1);
 			SetCvar("sm_weapons_enable", 1);
 			SetCvar("sm_warden_enable", 1);
 
 			g_iMPRoundTime.IntValue = g_iOldRoundTime;
+
 			MyJailbreak_SetEventDayName("none");
 			MyJailbreak_SetEventDayRunning(false);
-			CPrintToChatAll("%t %t", "catch_tag" , "catch_end");
+
+			CPrintToChatAll("%t %t", "catch_tag", "catch_end");
 		}
 	}
-	if (StartCatch)
-	{
-		LoopClients(i) CreateInfoPanel(i);
 
-		CPrintToChatAll("%t %t", "catch_tag" , "catch_next");
+	if (g_bStartCatch)
+	{
+		LoopClients(i)
+		{
+			CreateInfoPanel(i);
+		}
+
+		CPrintToChatAll("%t %t", "catch_tag", "catch_next");
 		PrintCenterTextAll("%t", "catch_next_nc");
 	}
 }
@@ -540,10 +618,11 @@ public void Event_RoundEnd(Event event, char[] name, bool dontBroadcast)
 
 public void Event_PlayerTeam(Event event, const char[] name, bool dontBroadcast)
 {
-	if (IsCatch == false)
+	if (g_bIsCatch == false)
 	{
 		return;
 	}
+
 	CheckStatus();
 
 	int iClient = GetClientOfUserId(event.GetInt("userid"));
@@ -554,156 +633,189 @@ public void Event_PlayerTeam(Event event, const char[] name, bool dontBroadcast)
 /******************************************************************************
                    FORWARDS LISTEN
 ******************************************************************************/
-
-
-//Initialize Event
+// Initialize Event
 public void OnMapStart()
 {
 	g_iVoteCount = 0;
 	g_iRound = 0;
-	IsCatch = false;
-	StartCatch = false;
+	g_bIsCatch = false;
+	g_bStartCatch = false;
 
 	g_iCoolDown = gc_iCooldownStart.IntValue + 1;
 
-	if (gc_bSounds.BoolValue) PrecacheSoundAnyDownload(g_sSoundFreezePath);
-	if (gc_bSounds.BoolValue) PrecacheSoundAnyDownload(g_sSoundUnFreezePath);
-	if (gc_bOverlays.BoolValue) PrecacheDecalAnyDownload(g_sOverlayFreeze);
+	if (gc_bSounds.BoolValue)
+	{
+		PrecacheSoundAnyDownload(g_sSoundFreezePath);
+		PrecacheSoundAnyDownload(g_sSoundUnFreezePath);
+	}
+
+	if (gc_bOverlays.BoolValue)
+	{
+		PrecacheDecalAnyDownload(g_sOverlayFreeze);
+	}
+
 	PrecacheSound("player/suit_sprint.wav", true);
 }
 
 
-//Map End
+// Map End
 public void OnMapEnd()
 {
-	IsCatch = false;
-	StartCatch = false;
+	g_bIsCatch = false;
+	g_bStartCatch = false;
 	g_iVoteCount = 0;
 	g_iRound = 0;
 	g_sHasVoted[0] = '\0';
 }
 
 
-//Terror win Round if time runs out
+// Terror win Round if time runs out
 public Action CS_OnTerminateRound( float &delay,  CSRoundEndReason &reason)
 {
-	if (IsCatch)   //TODO: does this trigger??
+	if (g_bIsCatch)   // TODO: does this trigger??
 	{
 		if (reason == CSRoundEnd_Draw)
 		{
 			reason = CSRoundEnd_TerroristWin;
 			return Plugin_Changed;
 		}
+
 		return Plugin_Continue;
 	}
+
 	return Plugin_Continue;
 }
 
 
-//Catch & Freeze
+// Catch & Freeze
 public Action OnTakedamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype)
 {
-	if (!IsValidClient(victim, true, false)|| attacker == victim || !IsValidClient(attacker, true, false)) return Plugin_Continue;
-
-	if (IsCatch == false)
+	if (!IsValidClient(victim, true, false) || attacker == victim || !IsValidClient(attacker, true, false))
 	{
 		return Plugin_Continue;
 	}
 
-	if (GetClientTeam(victim) == CS_TEAM_T && GetClientTeam(attacker) == CS_TEAM_CT && !catched[victim])
+	if (!g_bIsCatch)
 	{
-		if ((g_iCatchCounter[victim] >= gc_iCatchCount.IntValue) && (gc_iCatchCount.IntValue != 0)) ForcePlayerSuicide(victim);
-		else CatchEm(victim, attacker);
+		return Plugin_Continue;
+	}
+
+	if (GetClientTeam(victim) == CS_TEAM_T && GetClientTeam(attacker) == CS_TEAM_CT && !g_bCatched[victim])
+	{
+		if ((g_iCatchCounter[victim] >= gc_iCatchCount.IntValue) && (gc_iCatchCount.IntValue != 0))
+		{
+			ForcePlayerSuicide(victim);
+		}
+		else
+		{
+			CatchEm(victim, attacker);
+		}
+
 		CheckStatus();
 	}
-	if (GetClientTeam(victim) == CS_TEAM_T && GetClientTeam(attacker) == CS_TEAM_T && catched[victim] && !catched[attacker])
+
+	if (GetClientTeam(victim) == CS_TEAM_T && GetClientTeam(attacker) == CS_TEAM_T && g_bCatched[victim] && !g_bCatched[attacker])
 	{
 		FreeEm(victim, attacker);
 		CheckStatus();
 	}
+
 	return Plugin_Handled;
 }
 
 
 public void OnClientDisconnect_Post(int client)
 {
-	if (IsCatch == false)
+	if (!g_bIsCatch)
 	{
 		return;
 	}
+
 	CheckStatus();
 }
 
 
-//Set Client Hook
+// Set Client Hook
 public void OnClientPutInServer(int client)
 {
-	catched[client] = false;
+	g_bCatched[client] = false;
 	SDKHook(client, SDKHook_WeaponCanUse, OnWeaponCanUse);
 	SDKHook(client, SDKHook_TraceAttack, OnTakedamage);
 }
 
 
-//Knife only
+// Knife only
 public Action OnWeaponCanUse(int client, int weapon)
 {
 	char sWeapon[32];
 	GetEdictClassname(weapon, sWeapon, sizeof(sWeapon));
 
 	if (!StrEqual(sWeapon, "weapon_knife"))
+	{
+		if (IsValidClient(client, true, false))
 		{
-			if (IsValidClient(client, true, false))
+			if (g_bIsCatch)
 			{
-				if (IsCatch == true)
-				{
-					return Plugin_Handled;
-				}
+				return Plugin_Handled;
 			}
 		}
+	}
+
 	return Plugin_Continue;
 }
 
 
-//Listen for Last Lequest
+// Listen for Last Lequest
 public void OnAvailableLR(int Announced)
 {
-	if (IsCatch && gc_bAllowLR.BoolValue && (g_iTsLR > g_iTerrorForLR.IntValue))
+	if (g_bIsCatch && gc_bAllowLR.BoolValue && (g_iTsLR > g_iTerrorForLR.IntValue))
 	{
 		LoopValidClients(client, false, true)
 		{
-			SetEntData(client, FindSendPropInfo("CBaseEntity", "m_CollisionGroup"), 0, 4, true);
 			ClientSprintStatus[client] = 0;
-			CreateTimer( 0.0, DeleteOverlay, client );
+			g_bCatched[client] = false;
+
+			SetEntData(client, FindSendPropInfo("CBaseEntity", "m_CollisionGroup"), 0, 4, true);
+
+			CreateTimer(0.0, DeleteOverlay, client);
+
 			SetEntityRenderColor(client, 255, 255, 255, 0);
-			catched[client] = false;
 			SetEntityHealth(client, 100);
 
 			StripAllPlayerWeapons(client);
+
 			if (GetClientTeam(client) == CS_TEAM_CT)
 			{
 				FakeClientCommand(client, "sm_weapons");
 			}
+
 			GivePlayerItem(client, "weapon_knife");
 
-			if (gc_bWallhack.BoolValue) UnhookWallhack(client);
+			if (gc_bWallhack.BoolValue)
+			{
+				UnhookWallhack(client);
+			}
 		}
 
-		delete FreezeTimer;
-		delete BeaconTimer;
+		delete g_hFreezeTimer;
+		delete g_hBeaconTimer;
 
 		if (g_iRound == g_iMaxRound)
 		{
-			IsCatch = false;
+			g_bIsCatch = false;
 			g_iRound = 0;
 			Format(g_sHasVoted, sizeof(g_sHasVoted), "");
+
 			SetCvar("sm_hosties_lr", 1);
 			SetCvar("sm_weapons_enable", 1);
 			SetCvar("sm_warden_enable", 1);
 
 			g_iMPRoundTime.IntValue = g_iOldRoundTime;
+
 			MyJailbreak_SetEventDayName("none");
 			MyJailbreak_SetEventDayRunning(false);
-			CPrintToChatAll("%t %t", "catch_tag" , "catch_end");
+
+			CPrintToChatAll("%t %t", "catch_tag", "catch_end");
 		}
 	}
 }
@@ -711,23 +823,22 @@ public void OnAvailableLR(int Announced)
 /******************************************************************************
                    FUNCTIONS
 ******************************************************************************/
-
-
-//Prepare Event
+// Prepare Event
 void StartNextRound()
 {
-	StartCatch = true;
+	g_bStartCatch = true;
 	g_iCoolDown = gc_iCooldownDay.IntValue + 1;
 	g_iVoteCount = 0;
+
 	char buffer[32];
 	Format(buffer, sizeof(buffer), "%T", "catch_name", LANG_SERVER);
 	MyJailbreak_SetEventDayName(buffer);
 	MyJailbreak_SetEventDayPlanned(true);
 
-	g_iOldRoundTime = g_iMPRoundTime.IntValue; //save original round time
-	g_iMPRoundTime.IntValue = gc_iRoundTime.IntValue;//set event round time
+	g_iOldRoundTime = g_iMPRoundTime.IntValue; // save original round time
+	g_iMPRoundTime.IntValue = gc_iRoundTime.IntValue;// set event round time
 
-	CPrintToChatAll("%t %t", "catch_tag" , "catch_next");
+	CPrintToChatAll("%t %t", "catch_tag", "catch_next");
 	PrintCenterTextAll("%t", "catch_next_nc");
 }
 
@@ -737,18 +848,23 @@ void CatchEm(int client, int attacker)
 	SetEntityMoveType(client, MOVETYPE_NONE);
 	SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", 0.0);
 	SetEntityRenderColor(client, 0, 0, 205, 255);
-	catched[client] = true;
-	g_iCatchCounter[client]++;
+
+	g_bCatched[client] = true;
+	g_iCatchCounter[client] += 1;
+
 	ShowOverlay(client, g_sOverlayFreeze, 0.0);
+
 	if (gc_bSounds.BoolValue)
 	{
 		EmitSoundToAllAny(g_sSoundFreezePath);
 	}
+
 	if (!gc_bStayOverlay.BoolValue)
 	{
-		CreateTimer( 3.0, DeleteOverlay, client );
+		CreateTimer(3.0, DeleteOverlay, client);
 	}
-	CPrintToChatAll("%t %t", "catch_tag" , "catch_catch", attacker, client);
+
+	CPrintToChatAll("%t %t", "catch_tag", "catch_catch", attacker, client);
 }
 
 
@@ -757,51 +873,69 @@ void FreeEm(int client, int attacker)
 	SetEntityMoveType(client, MOVETYPE_WALK);
 	SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", 1.0);
 	SetEntityRenderColor(client, 255, 255, 255, 0);
-	catched[client] = false;
-	CreateTimer( 0.0, DeleteOverlay, client );
+
+	g_bCatched[client] = false;
+
+	CreateTimer(0.0, DeleteOverlay, client);
+
 	if (gc_bSounds.BoolValue)
 	{
 		EmitSoundToAllAny(g_sSoundUnFreezePath);
 	}
-	CPrintToChatAll("%t %t", "catch_tag" , "catch_unfreeze", attacker, client);
+
+	CPrintToChatAll("%t %t", "catch_tag", "catch_unfreeze", attacker, client);
 }
 
 
 void CheckStatus()
 {
-	int number = 0;
-	LoopClients(i) if (IsPlayerAlive(i) && GetClientTeam(i) == CS_TEAM_T && !catched[i]) number++;
-	if (number == 0)
+	int count = 0;
+	LoopClients(i)
 	{
-		CPrintToChatAll("%t %t", "catch_tag" , "catch_win");
+		if (IsPlayerAlive(i) && GetClientTeam(i) == CS_TEAM_T && !g_bCatched[i])
+		{
+			count++;
+		}
+	}
+
+	if (count == 0)
+	{
+		CPrintToChatAll("%t %t", "catch_tag", "catch_win");
+
 		CS_TerminateRound(5.0, CSRoundEnd_CTWin);
 		CreateTimer( 1.0, DeleteOverlay);
 	}
 }
 
 
-//Perpare client for wallhack
+// Perpare client for wallhack
 void Setup_WallhackSkin(int client)
 {
 	char sModel[PLATFORM_MAX_PATH];
 	GetClientModel(client, sModel, sizeof(sModel));
-	int iSkin = CPS_SetSkin(client, sModel, CPS_RENDER);
 
+	int iSkin = CPS_SetSkin(client, sModel, CPS_RENDER);
 	if (iSkin == -1)
+	{
 		return;
+	}
 
 	if (SDKHookEx(iSkin, SDKHook_SetTransmit, OnSetTransmit_Wallhack))
+	{
 		Setup_Wallhack(iSkin);
+	}
 }
 
 
-//set client wallhacked
+// set client wallhacked
 void Setup_Wallhack(int iSkin)
 {
 	int iOffset;
 
 	if (!iOffset && (iOffset = GetEntSendPropOffs(iSkin, "m_clrGlow")) == -1)
+	{
 		return;
+	}
 
 	SetEntProp(iSkin, Prop_Send, "m_bShouldGlow", true, true);
 	SetEntProp(iSkin, Prop_Send, "m_nGlowStyle", 0);
@@ -818,69 +952,79 @@ void Setup_Wallhack(int iSkin)
 }
 
 
-//Who can see wallhack if vaild
+// Who can see wallhack if vaild
 public Action OnSetTransmit_Wallhack(int iSkin, int client)
 {
 	if (!IsPlayerAlive(client))
+	{
 		return Plugin_Handled;
+	}
 
 	LoopClients(target)
 	{
 		if (!CPS_HasSkin(target))
+		{
 			continue;
+		}
 
-		if (!catched[target])
+		if (!g_bCatched[target])
+		{
 			continue;
+		}
 
 		if (EntRefToEntIndex(CPS_GetSkin(target)) != iSkin)
+		{
 			continue;
+		}
 
 		if (GetClientTeam(client) == CS_TEAM_CT)
-
-		return Plugin_Continue;
+		{
+			return Plugin_Continue;
+		}
 	}
 
 	return Plugin_Handled;
 }
 
 
-//remove wallhack
+// remove wallhack
 void UnhookWallhack(int client)
 {
 	if (IsValidClient(client, false, true))
 	{
 		char sModel[PLATFORM_MAX_PATH];
 		GetClientModel(client, sModel, sizeof(sModel));
-	//	SetEntProp(client, Prop_Send, "m_bShouldGlow", false, true);
+	// 	SetEntProp(client, Prop_Send, "m_bShouldGlow", false, true);
 		SDKUnhook(client, SDKHook_SetTransmit, OnSetTransmit_Wallhack);
 	}
 }
 
 
-
-
 /******************************************************************************
                    TIMER
 ******************************************************************************/
-
-
-//Start Timer
+// Start Timer
 public Action Timer_StartEvent(Handle timer)
 {
 	if (g_iFreezeTime > 1)
 	{
 		g_iFreezeTime--;
-		LoopClients(client) if (IsPlayerAlive(client))
+
+		LoopClients(client)
 		{
-			if (GetClientTeam(client) == CS_TEAM_CT)
+			if (IsPlayerAlive(client))
 			{
-				PrintCenterText(client, "%t", "catch_timetounfreeze_nc", g_iFreezeTime);
-			}
-			else if (GetClientTeam(client) == CS_TEAM_T)
-			{
-				PrintCenterText(client, "%t", "catch_timeuntilstart_nc", g_iFreezeTime);
+				if (GetClientTeam(client) == CS_TEAM_CT)
+				{
+					PrintCenterText(client, "%t", "catch_timetounfreeze_nc", g_iFreezeTime);
+				}
+				else if (GetClientTeam(client) == CS_TEAM_T)
+				{
+					PrintCenterText(client, "%t", "catch_timeuntilstart_nc", g_iFreezeTime);
+				}
 			}
 		}
+
 		return Plugin_Continue;
 	}
 
@@ -888,179 +1032,198 @@ public Action Timer_StartEvent(Handle timer)
 
 	if (g_iRound > 0)
 	{
-		LoopClients(client) if (IsPlayerAlive(client))
+		LoopClients(client)
 		{
-			if (GetClientTeam(client) == CS_TEAM_CT)
+			if (IsPlayerAlive(client))
 			{
-				SetEntityMoveType(client, MOVETYPE_WALK);
-				SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", 1.4);
-			}
+				if (GetClientTeam(client) == CS_TEAM_CT)
+				{
+					SetEntityMoveType(client, MOVETYPE_WALK);
+					SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", 1.4);
+				}
 
-			PrintCenterText(client, "%t", "catch_start_nc");
-			if (gc_bOverlays.BoolValue) ShowOverlay(client, g_sOverlayStartPath, 2.0);
-			if (gc_bSounds.BoolValue)
-			{
-				EmitSoundToAllAny(g_sSoundStartPath);
+				PrintCenterText(client, "%t", "catch_start_nc");
+
+				if (gc_bOverlays.BoolValue)
+				{
+					ShowOverlay(client, g_sOverlayStartPath, 2.0);
+				}
+
+				if (gc_bSounds.BoolValue)
+				{
+					EmitSoundToAllAny(g_sSoundStartPath);
+				}
+
+				if (gc_bWallhack.BoolValue)
+				{
+					Setup_WallhackSkin(client);
+				}
 			}
-			if (gc_bWallhack.BoolValue) Setup_WallhackSkin(client);
 		}
-		CPrintToChatAll("%t %t", "catch_tag" , "catch_start");
+
+		CPrintToChatAll("%t %t", "catch_tag", "catch_start");
 	}
-	FreezeTimer = null;
+
+	g_hFreezeTimer = null;
 
 	return Plugin_Stop;
 }
 
 
-//Beacon Timer
+// Beacon Timer
 public Action Timer_BeaconOn(Handle timer)
 {
-	LoopValidClients(i, true, false) MyJailbreak_BeaconOn(i, 2.0);
-	BeaconTimer = null;
+	LoopValidClients(i, true, false)
+	{
+		MyJailbreak_BeaconOn(i, 2.0);
+	}
+
+	g_hBeaconTimer = null;
 }
 
 
 /******************************************************************************
                    MENUS
 ******************************************************************************/
-
-
 void CreateInfoPanel(int client)
 {
-	//Create info Panel
+	// Create info Panel
 	char info[255];
 
-	CatchMenu = CreatePanel();
+	g_hCatchMenu = CreatePanel();
 	Format(info, sizeof(info), "%T", "catch_info_title", client);
-	SetPanelTitle(CatchMenu, info);
-	DrawPanelText(CatchMenu, "                                   ");
+	SetPanelTitle(g_hCatchMenu, info);
+	DrawPanelText(g_hCatchMenu, "                                   ");
 	Format(info, sizeof(info), "%T", "catch_info_line1", client);
-	DrawPanelText(CatchMenu, info);
-	DrawPanelText(CatchMenu, "-----------------------------------");
+	DrawPanelText(g_hCatchMenu, info);
+	DrawPanelText(g_hCatchMenu, "-----------------------------------");
 	Format(info, sizeof(info), "%T", "catch_info_line2", client);
-	DrawPanelText(CatchMenu, info);
+	DrawPanelText(g_hCatchMenu, info);
 	Format(info, sizeof(info), "%T", "catch_info_line3", client);
-	DrawPanelText(CatchMenu, info);
+	DrawPanelText(g_hCatchMenu, info);
 	Format(info, sizeof(info), "%T", "catch_info_line4", client);
-	DrawPanelText(CatchMenu, info);
+	DrawPanelText(g_hCatchMenu, info);
 	Format(info, sizeof(info), "%T", "catch_info_line5", client);
-	DrawPanelText(CatchMenu, info);
+	DrawPanelText(g_hCatchMenu, info);
 	Format(info, sizeof(info), "%T", "catch_info_line6", client);
-	DrawPanelText(CatchMenu, info);
+	DrawPanelText(g_hCatchMenu, info);
 	Format(info, sizeof(info), "%T", "catch_info_line7", client);
-	DrawPanelText(CatchMenu, info);
-	DrawPanelText(CatchMenu, "-----------------------------------");
+	DrawPanelText(g_hCatchMenu, info);
+	DrawPanelText(g_hCatchMenu, "-----------------------------------");
 	Format(info, sizeof(info), "%T", "warden_close", client);
-	DrawPanelItem(CatchMenu, info);
-	SendPanelToClient(CatchMenu, client, Handler_NullCancel, 20);
+	DrawPanelItem(g_hCatchMenu, info);
+	SendPanelToClient(g_hCatchMenu, client, Handler_NullCancel, 20);
 }
 
 
 /******************************************************************************
                    SPRINT MODULE
 ******************************************************************************/
-
-
-//Sprint
+// Sprint
 public Action Command_StartSprint(int client, int args)
 {
-	if (IsCatch)
+	if (!g_bIsCatch)
 	{
-		if (GetClientTeam(client) == CS_TEAM_T)
-		{
-			if (catched[client] == false)
-			{
-				if (gc_bSprint.BoolValue && client > 0 && IsClientInGame(client) && IsPlayerAlive(client) && GetClientTeam(client) > 1 && !(ClientSprintStatus[client] & IsSprintUsing) && !(ClientSprintStatus[client] & IsSprintCoolDown))
-				{
-					ClientSprintStatus[client] |= IsSprintUsing | IsSprintCoolDown;
-					SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", gc_fSprintSpeed.FloatValue);
-					EmitSoundToClient(client, "player/suit_sprint.wav", SOUND_FROM_PLAYER, SNDCHAN_AUTO, SNDLEVEL_NORMAL, SND_NOFLAGS, 0.8);
-					CReplyToCommand(client, "%t %t", "catch_tag" , "catch_sprint");
-					SprintTimer[client] = CreateTimer(gc_fSprintTime.FloatValue, Timer_SprintEnd, client);
-				}
-				return(Plugin_Handled);
-			}
-		}
+		CReplyToCommand(client, "%t %t", "catch_tag", "catch_disabled");
+		return Plugin_Handled;
 	}
-	else CReplyToCommand(client, "%t %t", "catch_tag" , "catch_disabled");
-	return(Plugin_Handled);
+
+	if (gc_bSprint.BoolValue || GetClientTeam(client) != CS_TEAM_T || g_bCatched[client])
+	{
+		return Plugin_Handled;
+	}
+
+	if (client > 0 && IsClientInGame(client) && IsPlayerAlive(client) && GetClientTeam(client) > 1 && !(ClientSprintStatus[client] & IsSprintUsing) && !(ClientSprintStatus[client] & IsSprintCoolDown))
+	{
+		ClientSprintStatus[client] |= IsSprintUsing | IsSprintCoolDown;
+
+		SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", gc_fSprintSpeed.FloatValue);
+		EmitSoundToClient(client, "player/suit_sprint.wav", SOUND_FROM_PLAYER, SNDCHAN_AUTO, SNDLEVEL_NORMAL, SND_NOFLAGS, 0.8);
+
+		CReplyToCommand(client, "%t %t", "catch_tag", "catch_sprint");
+
+		g_hSprintTimer[client] = CreateTimer(gc_fSprintTime.FloatValue, Timer_SprintEnd, client);
+	}
+
+	return Plugin_Handled;
 }
 
 
 public void OnGameFrame()
 {
-	if (IsCatch)
+	if (!g_bIsCatch || !gc_bSprintUse.BoolValue)
 	{
-		if (gc_bSprintUse.BoolValue)
-		{
-			LoopClients(i)
-			{
-				if (GetClientButtons(i) & IN_USE)
-				{
-					Command_StartSprint(i, 0);
-				}
-			}
-		}
 		return;
 	}
-	return;
+
+	LoopClients(i)
+	{
+		if (GetClientButtons(i) & IN_USE)
+		{
+			Command_StartSprint(i, 0);
+		}
+	}
 }
 
 
-public Action ResetSprint(int client)
+void ResetSprint(int client)
 {
-	if (SprintTimer[client] != null)
+	if (g_hSprintTimer[client] != null)
 	{
-		KillTimer(SprintTimer[client]);
-		SprintTimer[client] = null;
+		KillTimer(g_hSprintTimer[client]);
+		g_hSprintTimer[client] = null;
 	}
+
 	if (GetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue") != 1)
 	{
 		SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", 1.0);
 	}
+
 	if (ClientSprintStatus[client] & IsSprintUsing)
 	{
 		ClientSprintStatus[client] &= ~ IsSprintUsing;
 	}
-	return;
 }
 
 
 public Action Timer_SprintEnd(Handle timer, any client)
 {
-	SprintTimer[client] = null;
-
+	g_hSprintTimer[client] = null;
 
 	if (IsClientInGame(client) && (ClientSprintStatus[client] & IsSprintUsing))
 	{
 		SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", 1.0);
 		ClientSprintStatus[client] &= ~ IsSprintUsing;
+
 		if (IsPlayerAlive(client) && GetClientTeam(client) > 1)
 		{
-			SprintTimer[client] = CreateTimer(gc_iSprintCooldown.FloatValue, Timer_SprintCooldown, client);
-			CPrintToChat(client, "%t %t", "catch_tag" , "catch_sprintend", gc_iSprintCooldown.IntValue);
+			g_hSprintTimer[client] = CreateTimer(gc_iSprintCooldown.FloatValue, Timer_SprintCooldown, client);
+			CPrintToChat(client, "%t %t", "catch_tag", "catch_sprintend", gc_iSprintCooldown.IntValue);
 		}
 	}
-	return;
+
+	return Plugin_Handled;
 }
 
 
 public Action Timer_SprintCooldown(Handle timer, any client)
 {
-	SprintTimer[client] = null;
+	g_hSprintTimer[client] = null;
+
 	if (IsClientInGame(client) && (ClientSprintStatus[client] & IsSprintCoolDown))
 	{
 		ClientSprintStatus[client] &= ~ IsSprintCoolDown;
-		CPrintToChat(client, "%t %t", "catch_tag" , "catch_sprintagain", gc_iSprintCooldown.IntValue);
+		CPrintToChat(client, "%t %t", "catch_tag", "catch_sprintagain", gc_iSprintCooldown.IntValue);
 	}
-	return;
+
+	return Plugin_Handled;
 }
 
 
 public void Event_PlayerSpawn(Event event, const char[] name, bool dontBroadcast)
 {
-	int iClient = GetClientOfUserId(event.GetInt("userid"));
-	ResetSprint(iClient);
-	ClientSprintStatus[iClient] &= ~ IsSprintCoolDown;
-	return;
+	int client = GetClientOfUserId(event.GetInt("userid"));
+
+	ResetSprint(client);
+	ClientSprintStatus[client] &= ~ IsSprintCoolDown;
 }


### PR DESCRIPTION
This pull request contains several changes for Catch&Freeze EventDay:

1. I've refactored the code, to get rid of if-statements nesting.
2. Added late-loading processing.
3. Optimized TraceAttack hook, Wallhack staff, collision setup and some other minor things.
4. Fixed Wallhack removal: The glow-effect is being setup on a player skin as well as a SetTransmit hook, but the unhook of SetTransmit was done on the player, not his skin.