### PR TITLE
Add sm1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ sudo: false
 env:
   - VERSION=1.8
   - VERSION=1.9
+  - VERSION=1.10
+
+matrix:
+  allow_failures:
+    - env: VERSION=1.10
 
 script:
   - 'if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then bash ci/test.sh $VERSION $TRAVIS_BRANCH; fi'


### PR DESCRIPTION
But we should allow failures (it's a "new" dev version)

I use the same method for ttt ([example build](https://travis-ci.org/Bara/TroubleinTerroristTown/builds/336937858))