### PR TITLE
Fix compile error with sm1.11

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: bug / glitch
+assignees: ''
+
+---
+
+# Help us help you
+  - [ ] I have checked that my issue [doesn't exist yet](https://github.com/alliedmodders/sourcemod/issues).
+  - [ ] I have tried my absolute best to reduce the problem-space and have provided the absolute smallest test-case possible.
+  - [ ] I can always reproduce the issue with the provided description below.
+
+# Describe the bug
+A clear and concise description of what the bug is.
+
+# To Reproduce
+Steps to reproduce the behavior:
+1. Type command '...'
+2. Left click on '...'
+3. Crash
+
+# Logs
+Provide here any logs, such as error logs, console logs or any other log that could be useful.
+
+# Environment
+  * Operating System version: 
+  * Current SourceMod version: 
+  * Current Metamod: Source snapshot version:
+  * Current MyJailBreak version: https://shanapu.de/MyJailBreak/
+  - [ ] I have updated SourceMod to the [latest version](https://www.sourcemod.net/downloads.php) and it still happens. 
+  - [ ] I have updated SourceMM to the [latest snapshot](https://sourcemm.net/downloads.php?branch=dev) and it still happens.
+  - [ ] I have update MyJailBreak to the [latest dev version](https://shanapu.de/MyJailBreak) and it still happens.  
+
+
+# Screenshots
+If applicable, add screenshots to help explain your problem.
+
+# Additional context
+Add any other context about the problem here.

--- a/addons/sourcemod/scripting/include/lastrequest.inc
+++ b/addons/sourcemod/scripting/include/lastrequest.inc
@@ -64,20 +64,6 @@ enum DataType
 	Type_PartnerArray
 };
 
-enum LR_Structure
-{
-	DataType:LR_Type,
-	DataType:Prisoner_Index,
-	DataType:Guard_Index,
-	DataType:Prisoner_Data,
-	DataType:Guard_Data,
-	DataType:Global1,
-	DataType:Global2,
-	DataType:Global3,
-	DataType:Global4,
-	DataType:TheDataPack
-};
-
 public SharedPlugin __pl_lastrequest =
 {
 	name = "lastrequest",

--- a/install.txt
+++ b/install.txt
@@ -1,5 +1,5 @@
 Make sure you have the latest versions of the required plugins
-  
+ 
   
 Open gameserver folder and copy the folders addons/, cfg/, materials/, models/ & sound/ to your gameservers root csgo/ directory  
   


### PR DESCRIPTION
LR_Structure seems be unused, so why we still need it here? It also unused in the current master/beta version of Hosties (old stuff?).