### PR TITLE
Command spam fix

### DIFF
--- a/addons/sourcemod/scripting/MyJailbreak/Modules/Warden/handcuffs.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/Modules/Warden/handcuffs.sp
@@ -741,6 +741,8 @@ public Action Timer_StillPaperClip(Handle timer, int client)
 
 void StripZeus(int client)
 {
+	if (!gc_bPlugin.BoolValue || !g_bEnabled || !gc_bHandCuff.BoolValue)
+		return;
 	if (!IsValidClient(client, true, false))
 		return;
 

--- a/addons/sourcemod/translations/MyJailbreak.Warden.phrases.txt
+++ b/addons/sourcemod/translations/MyJailbreak.Warden.phrases.txt
@@ -953,13 +953,11 @@
 	
 	"warden_wait_spam_become"
 	{
-		"#format"	"{1:i}"
 		"en"		"You just decided to {green}retire as warden{default}! Please wait {purple}a few seconds{default} to become warden again."
 	}
 	
 	"warden_wait_spam_retire"
 	{
-		"#format"	"{1:i}"
 		"en"		"You just {green}became warden{default}! Please wait {purple}a few seconds{default} to retire."
 	}
 

--- a/addons/sourcemod/translations/MyJailbreak.Warden.phrases.txt
+++ b/addons/sourcemod/translations/MyJailbreak.Warden.phrases.txt
@@ -950,6 +950,18 @@
 		"#format"	"{1:i}"
 		"en"		"As {green}last round warden{default} you have to wait {purple}{1} seconds{default} to become warden again."
 	}
+	
+	"warden_wait_spam_become"
+	{
+		"#format"	"{1:i}"
+		"en"		"You just decided to {green}retire as warden{default}! Please wait {purple}a few seconds{default} to become warden again."
+	}
+	
+	"warden_wait_spam_retire"
+	{
+		"#format"	"{1:i}"
+		"en"		"You just {green}became warden{default}! Please wait {purple}a few seconds{default} to retire."
+	}
 
 	"warden_deputy_removed"
 	{


### PR DESCRIPTION
Edit: doesn't fix issue #371 

Prevents sm_w;sm_uw from being spammed because it created a lot of chat pollution.

Fixes Handcuffs' StripZeus() function that was executing even though the plugin was disabled, causing problems when playing with default tasers.

Other suggestion: fix TAB formatting on files, doing blank lines with no indentation while in a function/event is ugly and takes a lot of time to remove

Not tested, I hope it works. If it doesn't, I'll fix it. Feel free to edit my PR.