### PR TITLE
Crash exploit when warden fix

### DIFF
--- a/addons/sourcemod/scripting/MyJailbreak/Modules/Warden/handcuffs.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/Modules/Warden/handcuffs.sp
@@ -69,6 +69,7 @@ ConVar gc_iCuffedColorBlue;
 
 // Booleans
 bool g_bCuffed[MAXPLAYERS+1] = false;
+bool g_bClientIsDisconnecting[MAXPLAYERS+1]; // fixes StripZeus crash
 
 // Integers
 int g_iPlayerHandCuffs[MAXPLAYERS+1];
@@ -443,6 +444,7 @@ public void HandCuffs_OnClientDisconnect(int client)
 		g_iCuffed--;
 
 	g_iLastButtons[client] = 0;
+	g_bClientIsDisconnecting[client] = true;
 
 	if (BreakTimer[client] != null)
 	{
@@ -484,6 +486,7 @@ public void HandCuffs_OnMapEnd()
 public void HandCuffs_OnClientPutInServer(int client)
 {
 	g_iPlayerPaperClips[client] = 0;
+	g_bClientIsDisconnecting[client] = false;
 	SDKHook(client, SDKHook_OnTakeDamage, HandCuffs_OnTakedamage);
 }
 
@@ -743,6 +746,9 @@ void StripZeus(int client)
 {
 	if (!IsValidClient(client, true, false))
 		return;
+
+	if (g_bClientIsDisconnecting) // OnClientDisconnect is called BEFORE client fully disconnects, so he still passes IsValidClient check
+		return; // prevents infinite loops with #GameUI_Disconnect_TooManyCommands since FakeClientCommand is used
 
 	if ((!IsClientWarden(client) && (!IsClientDeputy(client) && gc_bHandCuffDeputy.BoolValue)))
 		return;

--- a/addons/sourcemod/scripting/MyJailbreak/Modules/Warden/handcuffs.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/Modules/Warden/handcuffs.sp
@@ -747,7 +747,7 @@ void StripZeus(int client)
 	if (!IsValidClient(client, true, false))
 		return;
 
-	if (g_bClientIsDisconnecting) // OnClientDisconnect is called BEFORE client fully disconnects, so he still passes IsValidClient check
+	if (g_bClientIsDisconnecting[client]) // OnClientDisconnect is called BEFORE client fully disconnects, so he still passes IsValidClient check
 		return; // prevents infinite loops with #GameUI_Disconnect_TooManyCommands since FakeClientCommand is used
 
 	if ((!IsClientWarden(client) && (!IsClientDeputy(client) && gc_bHandCuffDeputy.BoolValue)))

--- a/addons/sourcemod/scripting/MyJailbreak/warden.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/warden.sp
@@ -1241,6 +1241,8 @@ public void OnClientPutInServer(int client)
 // Warden disconnect
 public void OnClientDisconnect(int client)
 {
+	HandCuffs_OnClientDisconnect(client); // this is prioritised to fix a crash with the StripZeus function
+	
 	if (IsClientWarden(client))
 	{
 		CPrintToChatAll("%s %t", g_sPrefix, "warden_disconnected", client);
@@ -1248,8 +1250,6 @@ public void OnClientDisconnect(int client)
 		{
 			PrintCenterTextAll("%t", "warden_disconnected_nc", client);
 		}
-
-		HandCuffs_OnClientDisconnect(client); // this is prioritised to fix a crash with the StripZeus function
 
 		Forward_OnWardenRemoved(client);
 		Forward_OnWardenDisconnected(client);

--- a/addons/sourcemod/scripting/MyJailbreak/warden.sp
+++ b/addons/sourcemod/scripting/MyJailbreak/warden.sp
@@ -1249,6 +1249,8 @@ public void OnClientDisconnect(int client)
 			PrintCenterTextAll("%t", "warden_disconnected_nc", client);
 		}
 
+		HandCuffs_OnClientDisconnect(client); // this is prioritised to fix a crash with the StripZeus function
+
 		Forward_OnWardenRemoved(client);
 		Forward_OnWardenDisconnected(client);
 
@@ -1272,7 +1274,6 @@ public void OnClientDisconnect(int client)
 
 	Deputy_OnClientDisconnect(client);
 	Painter_OnClientDisconnect(client);
-	HandCuffs_OnClientDisconnect(client);
 	Freedays_OnClientDisconnect(client);
 }
 


### PR DESCRIPTION
Fixes #371 

Basically, it calls the OnClientDisconnected event for the Handcuffs module BEFORE triggering the event where the warden is removed, and it sets the new global bool g_bClientIsDisconnecting to true for the client. When this bool is set to true, it will NOT strip the taser from the player.

This should fix this exploit:

1. Become warden
2. Make youself kicked from the server by sending too much commands with the built-in server kick, for example by spamming "sm_w;sm_w;sm_w;sm_w;sm_w;sm_w;sm_w;sm_w;sm_w;sm_w;sm_w;sm_w;sm_w;sm_w;sm_w;sm_w;sm_w;sm_w;sm_w" (it works with every command that is from sourcemod, or some others that the server needs to reply to)
3. It will call a function to say that the warden was removed, calling StripZeus() on him. In normal conditions, it should fail because of IsValidClient(). The thing is OnClientDisconnect is called BEFORE the client is fully disconnected, so he still passes the check.
4. StripZeus() forces the client to send a client command (with FakeClientCommand()), making him kicked once again because of spamming. This is weird because it doesn't occur on a local server, the client is only kicked once. On a server that is not in LAN, it seems the client is kicked multiple times because of that.
5. client is kicked -> calls OnClientDisconnect again -> infinite loop -> crash

Not tested yet. It might be needed to apply this fix for the deputy too. Since I don't use it on my server, I can't know. If this exploit still exists with the deputy, please comment here or post a new issue with crash logs.